### PR TITLE
Bash wrapper to configure ConvertBinToVtu's parallel run.

### DIFF
--- a/util/binToVtu/RunConvertBinToVtu.bash
+++ b/util/binToVtu/RunConvertBinToVtu.bash
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Bash wrapper to run ConvertBinToVtu with OpenMP
+# The first argument specifies number of OpenMP threads to run the proram.
+# The second and third arguments are optional and specify the CPU affinitiy to run the program.
+# The rest of arguments are arguments required by the program itself.
+
+
+if [ $# -eq 0 ]; then
+	echo "$0 <num of threads> [-c <CPU affinity mask> (optional)] <Data directory> <Final time> <Output per sec>"
+	exit 0
+fi;
+
+export OMP_NUM_THREADS=$1
+shift
+
+if [ $1 = "-c" ]; then
+	MASK=$2
+	shift
+	shift
+	taskset -c $MASK ./ConvertBinToVtu $@
+else
+	./ConvertBinToVtu $@
+fi;
+
+

--- a/util/binToVtu/RunConvertBinToVtu.bash
+++ b/util/binToVtu/RunConvertBinToVtu.bash
@@ -4,6 +4,11 @@
 # The second and third arguments are optional and specify the CPU affinitiy to run the program.
 # The rest of arguments are arguments required by the program itself.
 
+#**Example**
+#To use 14 OpenMP threads and the first 14 CPU cores on the server's first CPU socket to run ConvertBinToVtu:
+#./RunConvertBinToVtu.bash 14 -c 0-13 ./np32_nlev13_sbtr01/ 3 20
+
+
 
 if [ $# -eq 0 ]; then
 	echo "$0 <num of threads> [-c <CPU affinity mask> (optional)] <Data directory> <Final time>"

--- a/util/binToVtu/RunConvertBinToVtu.bash
+++ b/util/binToVtu/RunConvertBinToVtu.bash
@@ -6,7 +6,7 @@
 
 
 if [ $# -eq 0 ]; then
-	echo "$0 <num of threads> [-c <CPU affinity mask> (optional)] <Data directory> <Final time> <Output per sec>"
+	echo "$0 <num of threads> [-c <CPU affinity mask> (optional)] <Data directory> <Final time>"
 	exit 0
 fi;
 


### PR DESCRIPTION
Bash wrapper to run ConvertBinToVtu with OpenMP

* The first argument specifies number of OpenMP threads to run the proram.
* The second and third arguments are optional and specify the CPU affinitiy to run the program.
* The rest of arguments are arguments required by the program itself.

**Example**

To use 14 OpenMP threads and the first 14 CPU cores on the server's first CPU socket to run ConvertBinToVtu:
```shell
./RunConvertBinToVtu.bash 14 -c 0-13 ./np32_nlev13_sbtr01/ 3 20
```